### PR TITLE
Handle boosts. Suggest editing toots too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Based on [a bot I used to use on Twitter called Please Caption](https://twitter.
 
 The difference with this bot is as you can send direct messages to statuses (toots) on Mastodon you can have a less spammy bot that messages privately.
 
-Mastodon also lets you 'Delete & re-draft' toots so you can easily add the text descriptions back in.
+Mastodon also lets you 'Delete & re-draft' toots so you can easily add the text descriptions back in. An alternative approach with Mastodon v4 is editing toots, but you have to remove the image and add it again before you can add text descriptions.
 
 ## How does the bot work?
 
 You can [follow the bot on @PleaseCaption@botsin.space](https://botsin.space/@PleaseCaption).
 
-When you post any media (images and videos) without text descriptions it will respond with a message.
+When you post any media (images and videos) without text descriptions, or boost such toots, it will respond with a message.
 
 ## Installing the bot
 

--- a/js/bot.js
+++ b/js/bot.js
@@ -25,11 +25,11 @@ function sendPrivateStatus (inReplyToId, username, reblog) {
 }
 
 function doesMessageHaveUnCaptionedImages(message) {
-  if (message.data.reblog) {
-    return doesMessageHaveUnCaptionedImages(message.data.reblog)
+  if (message.reblog) {
+    return doesMessageHaveUnCaptionedImages(message.reblog)
   }
 
-  const mediaAttachments = message.data.media_attachments
+  const mediaAttachments = message.media_attachments
   const hasMediaAttachments = mediaAttachments.length > 0
 
   if (!hasMediaAttachments) {
@@ -141,7 +141,7 @@ function sendMessagesToTimeline() {
     if (message.event === 'update') {
       console.info('Message ID: ', message.data.id)
       
-      if (!doesMessageHaveUnCaptionedImages(message)) {
+      if (!doesMessageHaveUnCaptionedImages(message.data)) {
         return
       }
 

--- a/js/bot.js
+++ b/js/bot.js
@@ -15,16 +15,20 @@ const {
   getRelationships
 } = require('./mastodon' )
 
-function sendPrivateStatus (inReplyToId, username) {
+function sendPrivateStatus (inReplyToId, username, reblog) {
   const params = {
     in_reply_to_id: inReplyToId,
-    status: `${username} ${getRandomText()}`,
+    status: `${username} ${getRandomText(reblog)}`,
     visibility: 'direct'
   }
   return sendStatus(params)
 }
 
 function doesMessageHaveUnCaptionedImages(message) {
+  if (message.data.reblog) {
+    return doesMessageHaveUnCaptionedImages(message.data.reblog)
+  }
+
   const mediaAttachments = message.data.media_attachments
   const hasMediaAttachments = mediaAttachments.length > 0
 
@@ -146,10 +150,10 @@ function sendMessagesToTimeline() {
         return
       }
 
-      const messageId = message.data.id
+      const messageId = message.data.reblog ? message.data.reblog.id : message.data.id;
       const username = '@' + message.data.account.acct
 
-      sendPrivateStatus(messageId, username).then(result => {
+      sendPrivateStatus(messageId, username, message.data.reblog).then(result => {
         console.info('Sent message to: ', result.id)
       }).catch(console.error)
     }

--- a/js/grammar.json
+++ b/js/grammar.json
@@ -16,9 +16,9 @@
     "Help make Mastodon more accessible by adding descriptions to your media!"
   ],
   "deleteredraft": [
-    "Not too late to delete and re-draft.",
-    "You can choose 'Delete & re-draft' and add them.",
-    "If you want to add them, choose 'Delete & re-draft'."
+    "Not too late to delete and re-draft. Or, edit, remove and re-add media, and add captions.",
+    "You can choose 'Delete & re-draft' and add them, or if it's easier, 'Edit', remove and re-add the media.",
+    "If you want to add them, choose (1) 'Delete & re-draft' or (2) 'Edit', remove, then add."
   ]
 }
 

--- a/js/mastodon.js
+++ b/js/mastodon.js
@@ -60,7 +60,7 @@ function deleteStatus (id) {
 }
 
 function followUser (accountId) {
-  return mastodonClient.post(`accounts/${accountId}/follow`, { reblogs: false })
+  return mastodonClient.post(`accounts/${accountId}/follow`, { reblogs: true })
     .then(resp => resp.data.id)
 }
 

--- a/js/reblogGrammar.json
+++ b/js/reblogGrammar.json
@@ -1,0 +1,24 @@
+{
+  "origin": [
+    "#words# #emojis# \n\n#deleteredraft#"
+  ],
+  "emojis": [
+    "📷", "📸", "🤳", "🎥", "📹", "♻️", "🆙", "👆", "☝️", "", "", "", "", ""
+  ],
+  "words": [
+    "Oops, you boosted something without media captions!"
+    "Hey, your boosted toot's media don't all have descriptions!",
+    "Psst, you boosted something that's missing descriptions",
+    "Your boosted toot's media doesn't have descriptions, just so you know!",
+    "Blind and/or partially sighted people may have trouble with the toot you boosted",
+    "It makes Mastodon more accessible when media have captions. This boost doesn't.",
+  ],
+  "deleteredraft": [
+    "The author can delete and re-draft. Or, edit, remove and re-add media, and add captions.",
+    "The author can choose 'Delete & re-draft' and add them, or if it's easier, 'Edit', remove and re-add the media.",
+    "If the author wants to add them, they can choose (1) 'Delete & re-draft' or (2) 'Edit', remove, then add."
+  ]
+}
+
+
+

--- a/js/reblogGrammar.json
+++ b/js/reblogGrammar.json
@@ -6,12 +6,12 @@
     "📷", "📸", "🤳", "🎥", "📹", "♻️", "🆙", "👆", "☝️", "", "", "", "", ""
   ],
   "words": [
-    "Oops, you boosted something without media captions!"
+    "Oops, you boosted something without media captions!",
     "Hey, your boosted toot's media don't all have descriptions!",
     "Psst, you boosted something that's missing descriptions",
     "Your boosted toot's media doesn't have descriptions, just so you know!",
     "Blind and/or partially sighted people may have trouble with the toot you boosted",
-    "It makes Mastodon more accessible when media have captions. This boost doesn't.",
+    "It makes Mastodon more accessible when media have captions. This boost doesn't."
   ],
   "deleteredraft": [
     "The author can delete and re-draft. Or, edit, remove and re-add media, and add captions.",

--- a/js/text.js
+++ b/js/text.js
@@ -1,10 +1,14 @@
 const tracery = require('tracery-grammar')
-const rawGrammar = require('./grammar.json')
-const processedGrammar = tracery.createGrammar(rawGrammar)
-processedGrammar.addModifiers(tracery.baseEngModifiers)
+const grammar = tracery.createGrammar(require('./grammar.json'))
+grammar.addModifiers(tracery.baseEngModifiers)
+const reblogGrammar = tracery.createGrammar(require('./reblogGrammar.json'))
+reblogGrammar.addModifiers(tracery.baseEngModifiers)
 
-function getRandomText () {
-  const text = processedGrammar.flatten("#origin#")
+function getRandomText (reblog) {
+  if (reblog) {
+    return reblogGrammar.flatten('#origin#')
+  }
+  const text = grammar.flatten('#origin#')
   return text
 }
 


### PR DESCRIPTION
Hi! I'm @22@octodon.social from https://toot.cafe/@zac/109585961042545178. I know I said it should be a tiny change to get PleaseCaption to handle boosts and it was but of course you'd want the bot to say something else when boosts are involved, so I created a new grammar for the boost case and updated the logic to use the that vs the original grammar depending.

Then I noticed that the old grammar only suggested delete-and-redraft. Since Mastodon v4 we can edit toots, but apparently there's a glitch where you have to remove the image and re-add it in order to add captions: https://queer.party/@Rachel_Thorn/109585432701507201

~I've signed up for an account for botsin.space but they're reviewing it so I haven't tested it, forgive me. Making this PR untested in case you have an easy way to make sure it works as advertised? If not, no worries! I'll get a second account and test it.~ See commentary below :)

Thanks for this!