### PR TITLE
disable #5: no longer notify on boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Based on [a bot I used to use on Twitter called Please Caption](https://twitter.
 
 The difference with this bot is as you can send direct messages to statuses (toots) on Mastodon you can have a less spammy bot that messages privately.
 
-Mastodon also lets you 'Delete & re-draft' toots so you can easily add the text descriptions back in. An alternative approach with Mastodon v4 is editing toots, but you have to remove the image and add it again before you can add text descriptions.
+Mastodon also lets you edit toots so you can easily add text descriptions.
 
 ## How does the bot work?
 
 You can [follow the bot on @PleaseCaption@botsin.space](https://botsin.space/@PleaseCaption).
 
-When you post any media (images and videos) without text descriptions, or boost such toots, it will respond with a message.
+When you post any media (images and videos) without text descriptions, it will respond with a message.
 
 ## Installing the bot
 
@@ -35,3 +35,6 @@ npm install
 The bot will unfollow and follow users ever so often when you hit a specific endpoint. If your server is 'https://example.com' and your `BOT_ENDPOINT` is 'specialsecret' the URL would be 'https://example.com/specialsecret'.
 
 Then you can use something like [Uptime Robot](https://Uptimerobot.com) to send requests to that URL ever so often.
+
+## Changelog
+- We began notifying people when they boosted un-captioned content (see [PR](https://github.com/zactopus/please-caption-mastodon/pull/5)) but we have reverted this feature because there isn't a reliable way to detect edits to boosts (see [issue](https://github.com/zactopus/please-caption-mastodon/issues/12))

--- a/js/bot.js
+++ b/js/bot.js
@@ -27,7 +27,9 @@ function sendPrivateStatus(inReplyToId, username, reblog) {
 
 function doesMessageHaveUnCaptionedImages(message) {
   if (message.reblog) {
-    return doesMessageHaveUnCaptionedImages(message.reblog);
+    // We don't have a simple and reliable way to detect edited reblogs, so just skip this for now
+    // return doesMessageHaveUnCaptionedImages(message.reblog);
+    return;
   }
 
   const mediaAttachments = message.media_attachments;

--- a/js/grammar.json
+++ b/js/grammar.json
@@ -12,8 +12,8 @@
     "Help make Mastodon more accessible by adding descriptions to your media!"
   ],
   "deleteredraft": [
-    "Not too late to delete and re-draft. Or, edit, remove and re-add media, and add captions.",
-    "You can choose 'Delete & re-draft' and add them, or if it's easier, 'Edit', remove and re-add the media.",
-    "If you want to add them, choose (1) 'Delete & re-draft' or (2) 'Edit', remove, then add."
+    "Not too late to edit and add captions.",
+    "You can choose 'Edit' and add them.",
+    "If you want to add them, choose 'Edit', then add."
   ]
 }

--- a/js/mastodon.js
+++ b/js/mastodon.js
@@ -61,7 +61,7 @@ function deleteStatus(id) {
 
 function followUser(accountId) {
   return mastodonClient
-    .post(`accounts/${accountId}/follow`, { reblogs: true })
+    .post(`accounts/${accountId}/follow`, { reblogs: false })
     .then((resp) => resp.data.id);
 }
 


### PR DESCRIPTION
See zactopus/please-caption-mastodon#12 for details. If we find a reliable and simple way to detect that a boost has been edited, this PR can be reverted but for now this is causing too many false alarms.

Bonus: this PR also simplifies the text we send. Instead of suggesting redraft, most instances have updated to a version that allows editing.