### PR TITLE
unfollow someone if they send STOP

### DIFF
--- a/js/bot.js
+++ b/js/bot.js
@@ -172,7 +172,7 @@ async function processNotificationEvent(message) {
   // an alternative to them just blocking us, and more lightweight than enumerating over all of the
   // people we follow (thousands at this point, in 2023).
   if (type === "mention") {
-    if (STOP_REGEXP.test(status.content)) {
+    if (status.mentions.length === 1 && STOP_REGEXP.test(status.content)) {
       const [{ following, followed_by }] = await getRelationships([
         status.account.id,
       ]);

--- a/js/bot.js
+++ b/js/bot.js
@@ -132,7 +132,9 @@ function compareFollowersToFollowing() {
   });
 }
 
-function processNotificationEvent(message) {
+const STOP_REGEXP = /\bSTOP\b/;
+
+async function processNotificationEvent(message) {
   const { status, account, type } = message.data;
 
   // if a user follows the bot
@@ -142,6 +144,7 @@ function processNotificationEvent(message) {
         console.info("Followed back: ", result);
       })
       .catch(console.error);
+    return;
   }
 
   // if a user favourites the bot's toot
@@ -162,7 +165,26 @@ function processNotificationEvent(message) {
         console.info("Deleted status via user favourite: ", result.id);
       })
       .catch(console.error);
+    return;
   }
+
+  // If a user sends "STOP" as a word in their toot and they don't follow me, unfollow them. This is
+  // an alternative to them just blocking us, and more lightweight than enumerating over all of the
+  // people we follow (thousands at this point, in 2023).
+  if (type === "mention") {
+    if (STOP_REGEXP.test(status.content)) {
+      const [{ following, followed_by }] = await getRelationships([
+        status.account.id,
+      ]);
+      if (following && !followed_by) {
+        await unfollowUser(status.account.id);
+        console.info(`Unfollowed ${status.account.id} via STOP: ${status.id}`);
+      }
+    }
+    return;
+  }
+
+  console.log("unhandled notification", type, status.id);
 }
 
 function processDeleteEvent(message) {

--- a/js/bot.js
+++ b/js/bot.js
@@ -203,11 +203,11 @@ function sendFarewell(inReplyToId, username) {
     in_reply_to_id: inReplyToId,
     status: `${username} Hi!
 
-This bot received your "STOP" and will stop following you.
+This bot received your "STOP" 🛑 and will stop following you.
 
-If this was accidental, or if you ever want to receive these notifications again, just follow again.
+If this was accidental, or if you ever want to receive these notifications again, follow once again 🔄.
 
-Best wishes!`,
+👋 Best wishes!`,
     visibility: "direct",
   };
   console.log("Sending farewell", inReplyToId, username);

--- a/js/bot.js
+++ b/js/bot.js
@@ -203,9 +203,9 @@ function sendFarewell(inReplyToId, username) {
     in_reply_to_id: inReplyToId,
     status: `${username} Hi!
 
-This bot received your "STOP" 🛑 and will stop following you.
+This bot received your "STOP" 🛑 and has stopped following you.
 
-If this was accidental, or if you ever want to receive these notifications again, follow once again 🔄.
+If this was accidental, or if you ever want to receive these notifications again, follow once again 🔄
 
 👋 Best wishes!`,
     visibility: "direct",

--- a/js/db.js
+++ b/js/db.js
@@ -14,7 +14,7 @@
  *    we've replied to in memory instead of loading the server.
  * 2. `search` and `warnTootedUncaptioned` because this is a proposed way to detect whether a boost
  *    lacking image captions has been edited.
- * 3. `relationships` because this will be used to detect STOP requests to unfollow (see #14)
+ * 3. `relationships` because this is used to detect STOP requests to `unfollow` (see #14)
  */
 
 // Initialize and load the db
@@ -44,6 +44,7 @@ function initializeRequests() {
     deleteBecauseTheyFaved: 0,
     deletedNothingThoTheyDeleted: 0,
     relationships: 0,
+    unfollow: 0,
     search: 0,
     warnTootedUncaptioned: 0,
     // warnBoostedUncaptioned: 0,
@@ -70,6 +71,9 @@ function search() {
 function relationships() {
   requestsPerType.relationships++;
 }
+function unfollow() {
+  requestsPerType.unfollow++;
+}
 function warnTootedUncaptioned() {
   requestsPerType.warnTootedUncaptioned++;
 }
@@ -92,6 +96,7 @@ module.exports = {
   deletedNothingThoTheyDeleted,
   deleteStatus,
   relationships,
+  unfollow,
   search,
   warnTootedUncaptioned,
 };

--- a/js/mastodon.js
+++ b/js/mastodon.js
@@ -68,6 +68,7 @@ function followUser(accountId) {
 }
 
 function unfollowUser(accountId) {
+  db.unfollow();
   return mastodonClient
     .post(`accounts/${accountId}/unfollow`, {})
     .then((resp) => resp.data.id);

--- a/js/text.js
+++ b/js/text.js
@@ -5,6 +5,8 @@ const reblogGrammar = tracery.createGrammar(require("./reblogGrammar.json"));
 reblogGrammar.addModifiers(tracery.baseEngModifiers);
 
 const FAVOURITE_TOOT_TO_DELETE_STRING = "⭐ Favourite this toot to delete it.";
+const STOP_STRING =
+  "🛑 Unfollow and reply STOP to stop receiving these notifications.";
 
 function getFlattenedGrammar(reblog) {
   if (reblog) {
@@ -16,7 +18,11 @@ function getFlattenedGrammar(reblog) {
 
 function getRandomText(reblog) {
   const flattenendGrammar = getFlattenedGrammar(reblog);
-  return `${flattenendGrammar} \n\n${FAVOURITE_TOOT_TO_DELETE_STRING}`;
+  return `${flattenendGrammar}
+
+${FAVOURITE_TOOT_TO_DELETE_STRING}
+
+${STOP_STRING}`;
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes https://github.com/zactopus/please-caption-mastodon/issues/11. This is a feature suggested by Ted Young: if someone replies `STOP` to us (whole word, exact case), and they don't follow us, we should stop following them so we stop sending them notifications. 

This is an alternative to what we've been telling people: just block the bot.

Note that the bot does have a way to fetch all accounts its following and ensure they're following us back (and unfollow anyone who isn't following us any more) but we don't use this because we have thousands of followers and we'll run into server rate limits if we do this with any regularity.

There is a cost to this: every time we receive `STOP`, we hit the `/relationships` endpoint to see if they follow us/we follow them.

If we do wind up unfollowing, we send them a farewell DM to confirm.

<img width="319" alt="image" src="https://github.com/zactopus/please-caption-mastodon/assets/37649/97cac1cc-78c7-45a0-b170-ad4351f4c9df">
