### PR TITLE
Use Node 16 on Glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "devDependencies": {
     "dotenv": "^16.0.3"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
I don't know if this is actually required but I think Glitch's default Node 10 might have problems with the `mastodon-api` fork I introduced in https://github.com/zactopus/please-caption-mastodon/pull/15 (I couldn't `pnpm install` locally because of some `yarn` issue?? And per [Glitch docs](https://help.glitch.com/hc/en-us/articles/16287495688845-Can-I-change-the-version-of-node-js-my-project-uses-), Node <14 uses pnpm).

Confirmed with Node 16 that `npm install` finishes fine and the app starts.