### PR TITLE
reply cache to delete our DM if they delete

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -17,6 +17,8 @@
  * 3. `relationships` because this will be used to detect STOP requests to unfollow (see #14)
  */
 
+const { STATUS_TO_REPLY_CACHE } = require("./replyCache");
+
 // Initialize and load the db
 const db = require("better-sqlite3")(".data/logs.db");
 db.pragma("journal_mode = WAL");
@@ -78,6 +80,7 @@ function warnTootedUncaptioned() {
 const WINDOW_SECONDS = 30 * 60;
 const insertStatement = db.prepare(`insert into logs values (?, ?, ?)`);
 const dbInterval = setInterval(() => {
+  requestsPerType.cacheSize = STATUS_TO_REPLY_CACHE.size;
   insertStatement.run(
     Date.now(),
     WINDOW_SECONDS,

--- a/js/db.js
+++ b/js/db.js
@@ -45,6 +45,7 @@ function initializeRequests() {
     deleteBecauseTheyDeleted: 0,
     deleteBecauseTheyFaved: 0,
     deletedNothingThoTheyDeleted: 0,
+    deleteBecauseTheyEdited: 0,
     relationships: 0,
     search: 0,
     warnTootedUncaptioned: 0,
@@ -65,6 +66,9 @@ function deleteBecauseTheyFaved() {
 }
 function deletedNothingThoTheyDeleted() {
   requestsPerType.deletedNothingThoTheyDeleted++;
+}
+function deleteBecauseTheyEdited() {
+  requestsPerType.deleteBecauseTheyEdited++;
 }
 function search() {
   requestsPerType.search++;
@@ -93,6 +97,7 @@ module.exports = {
   deleteBecauseTheyDeleted,
   deleteBecauseTheyFaved,
   deletedNothingThoTheyDeleted,
+  deleteBecauseTheyEdited,
   deleteStatus,
   relationships,
   search,

--- a/js/replyCache.js
+++ b/js/replyCache.js
@@ -1,0 +1,35 @@
+/**
+ * When we receive a delete notification, it'd be nice to see if we replied to the deleted message
+ * and if so, delete our reply.
+ *
+ * In this module we keep a mapping from other people's message IDs to our replies, to aid that.
+ *
+ * Initial testing shows that we receive about 10~ deletes an hour, a fraction of which we reply to.
+ * So a cache of size 10_000 will fill in ~416 days assuming 10% deletes we receive have a reply
+ * from us.
+ *
+ * Under such load, we don't have to check the cache size very frequently. We *do* want to cap the
+ * size of the cache to a sane value because we don't want this to be a memory burden. So, every few
+ * hours/days, we evict the oldest entries in the cache till it's small enough. (This is easy
+ * because JavaScript Maps iterate in insert order.)
+ */
+
+const STATUS_TO_REPLY_CACHE = new Map();
+const MAX_CACHE_SIZE = 10_000;
+const CACHE_CLEAR_TIMEOUT_MS = 1e3 * 3600 * 12;
+
+setInterval(() => {
+  const size = STATUS_TO_REPLY_CACHE.size;
+  let surplus = size - MAX_CACHE_SIZE;
+  if (surplus > 0) {
+    for (const entry of STATUS_TO_REPLY_CACHE) {
+      STATUS_TO_REPLY_CACHE.delete(entry);
+      surplus--;
+      if (surplus <= 0) {
+        break;
+      }
+    }
+  }
+}, CACHE_CLEAR_TIMEOUT_MS);
+
+module.exports = { STATUS_TO_REPLY_CACHE };


### PR DESCRIPTION
Previously, if we received a notification that someone deleted a toot, we asked our server for our most recent sent toots to see if we could find a reply to the deleted toot. If we found such a reply, we'd delete it (so it's not cluttering the other user's DMs).

Most of the time this does nothing because
1. the vast majority of deletes are of messages that we haven't responded to (i.e., either with no images or with captions).
2. But also because we can only ask the server for our most recent messages and we might have sent a reply to the now-deleted a while ago.

Instead of burdening the server to do this unlikely-to-be-useful search, this PR proposes an alternative: we store in memory a cache mapping other people's message IDs to our replies. When we DM someone about missing captions, it creates an entry in the cache. If we get a delete, we check the cache for the deleted message ID and if we find a hit, we delete our message and delete the entry from the cache.

We don't want the cache to grow infinitely so we cap it at some reasonable value (10'000 entries in this PR), and every 12 hours we run a cleanup operation to bring it to that size if it's grown beyond it.

Upsides:
- we don't burden the server
- we will likely detect and delete even months-old replies
  - (assuming the server stays running that long)

Downsides:
- the cache is in-memory and not persisted to disk. We lose the cache every time the server reboots (which is every few days recently, since I'm adding features).
  - we could save the cache to disk every few hours and on server shutdown but I don't want to have a random list of people's message IDs (that botsin.space has assigned) on the Glitch server, seems like a privacy 🤢

Bonus:
- we now also listen to *edit* messages and delete our DM if someone edits their toot and adds captions!


Potential enhancements:
- later once we detect missing captions in people's boosts, we should detect if someone has unboosted and delete our DM to them too
- [ ] TODO now: delete from our cache when someone favorites our DM

(My overall goal to reduce server load is so we can turn on boost analysis 😇)